### PR TITLE
Mpris support and UI improvements

### DIFF
--- a/harbour-nettiradio.desktop
+++ b/harbour-nettiradio.desktop
@@ -6,3 +6,8 @@ Exec=sailfish-qml harbour-nettiradio
 Name=Nettiradio
 Name[en]=Netradio
 Name[fi]=Nettiradio
+
+[X-Sailjail]
+Permissions=Audio;Internet
+OrganizationName=harbour-nettiradio
+ApplicationName=harbour-nettiradio

--- a/qml/Pages/FavDialog.qml
+++ b/qml/Pages/FavDialog.qml
@@ -38,6 +38,7 @@ import "functions.js" as TheFunctions // :)
 Dialog {
     id: dialog
     property string title
+    property alias dialogTitle: header.title
     property string source: "http://"
     property string site: "http://"
     property bool updateMode: false
@@ -51,6 +52,7 @@ Dialog {
             spacing: Theme.paddingLarge
 
             DialogHeader {
+                id: header
                 title: qsTr("Muokkaa suosikkia")}
 
             TextArea {
@@ -80,17 +82,6 @@ Dialog {
                 placeholderText: qsTr("Aseman nettisivu")
                 label: qsTr("Aseman nettisivu")
                 EnterKey.onClicked: focus = false
-            }
-            Button {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("Lisää nykyinen asema")
-                enabled: !updateMode
-                onClicked: {
-                    titleInput.text = lib.radioStation
-                    sourceInput.text = lib.musicSource
-                    siteInput.text = lib.website
-                    dialog.accept()
-                }
             }
         }
     }

--- a/qml/Pages/FavManager.qml
+++ b/qml/Pages/FavManager.qml
@@ -71,7 +71,7 @@ Page {
             }
             MenuItem {
                 text: qsTr("Lisää asema")
-                onClicked: pageStack.push(Qt.resolvedUrl("FavDialog.qml"))
+                onClicked: pageStack.push(Qt.resolvedUrl("FavDialog.qml"), { dialogTitle: qsTr("Lisää asema") })
             }
         }
         ViewPlaceholder {

--- a/qml/Pages/PlayerPanel.qml
+++ b/qml/Pages/PlayerPanel.qml
@@ -43,13 +43,24 @@ DockedPanel {
         spacing: Theme.paddingLarge
         Button {
             anchors.verticalCenter: parent.verticalCenter
-            text: Screen.sizeCategory > Screen.Medium
-                  ? lib.radioStation
-                  : mainPage.isPortrait
-                    ? lib.radioStation.slice(0,23)
-                    : lib.radioStation
+            preferredWidth: isPortrait ? Theme.buttonWidthSmall : Theme.buttonWidthLarge
             RemorsePopup {id: remorse}
             onClicked: openWebsite()
+
+            Label {
+                anchors.centerIn: parent
+                width: parent.width - (Theme.paddingMedium * 2)
+                text: lib.radioStation
+                horizontalAlignment: metrics.width > width ? Text.AlignLeft : Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                truncationMode: TruncationMode.Fade
+            }
+
+            Label {
+                id: metrics
+                opacity: 0.0
+                text: lib.radioStation
+            }
         }
         MediaButton {
             source: "icon-l-stop.png"

--- a/qml/Pages/StationGridView.qml
+++ b/qml/Pages/StationGridView.qml
@@ -63,7 +63,6 @@ SilicaFlickable {
                 playStream()
                 lib.website = (Qt.resolvedUrl(site))
                 lib.panelOpen = true
-                refreshMpris()
             }
 
             Row {

--- a/qml/Pages/StationListView.qml
+++ b/qml/Pages/StationListView.qml
@@ -144,26 +144,41 @@ SilicaFlickable {
             }
         }
         delegate: ListItem {
+            property bool currentlyPlaying: source === lib.musicSource
+
             width: listView.width
-            highlighted: down || (source === lib.musicSource) // note to self: make sure this works
-            Label {
-                text: Theme.highlightText(model.title, searchField.lowercaseText, Theme.highlightColor)
-                textFormat: Text.StyledText
-                color: highlighted ? Theme.highlightColor : Theme.primaryColor
-                font.pixelSize: Screen.sizeCategory > Screen.Medium
-                                ? Theme.fontSizeExtraLarge * lib.fontSize
-                                : Theme.fontSizeMedium * lib.fontSize
-                anchors.verticalCenter: parent.verticalCenter
-                x: source === lib.musicSource ? Theme.paddingLarge*3 : Theme.paddingLarge
-            }
+            highlighted: down || currentlyPlaying // note to self: make sure this works
+
             IconButton {
+                id: playingIcon
                 icon.source: "image://theme/icon-m-media"
                 anchors {
                     left: parent.left
                     verticalCenter: parent.verticalCenter
                 }
-                opacity: source === lib.musicSource ? 1.0 : 0.0
+                opacity: currentlyPlaying ? 1.0 : 0.0
+                width: currentlyPlaying ? height : Theme.paddingLarge
+                Behavior on width { NumberAnimation {} }
+                Behavior on opacity { NumberAnimation {} }
+                visible: opacity > 0.0
             }
+
+            Label {
+                text: Theme.highlightText(model.title, searchField.lowercaseText, Theme.highlightColor)
+                textFormat: Text.StyledText
+                verticalAlignment: Text.AlignVCenter
+                truncationMode: TruncationMode.Fade
+                color: highlighted ? Theme.highlightColor : Theme.primaryColor
+                font.pixelSize: Screen.sizeCategory > Screen.Medium
+                                ? Theme.fontSizeExtraLarge * lib.fontSize
+                                : Theme.fontSizeMedium * lib.fontSize
+                anchors {
+                    left: playingIcon.right
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                }
+            }
+
             onClicked: {
                 TheFunctions.chooseStation((searchMode ? filteredModel : qmlListModel), index)
                 playStream()

--- a/qml/Pages/StationListView.qml
+++ b/qml/Pages/StationListView.qml
@@ -81,16 +81,19 @@ SilicaFlickable {
     SearchField {
         id: searchField
         property string lowercaseText
+        property bool searching: false
         height: mainPage.searchMode ? implicitHeight : 0.0
         Behavior on height { NumberAnimation {} }
         clip: true
         anchors.top: pageHeader.bottom
         width: parent.width
         onTextChanged: {
+            searching = true
             lowercaseText = text.toLowerCase()
             getSortedItems(lowercaseText)
             listView.positionViewAtIndex(0,ListView.Beginning)
             lib.panelOpen = false
+            searching = false
         }
         inputMethodHints: Qt.ImhNoPredictiveText
         placeholderText: qsTr("Hae")
@@ -144,6 +147,17 @@ SilicaFlickable {
             }
         }
         delegate: ListItem {
+            id: stationItem
+
+            ListView.onRemove: RemoveAnimation {
+                target: stationItem
+                duration: searchField.searching ? 0 : 150
+            }
+            ListView.onAdd: AddAnimation {
+                target: stationItem
+                duration: searchField.searching ? 0 : 150
+            }
+
             property bool currentlyPlaying: source === lib.musicSource
 
             width: listView.width

--- a/qml/Pages/functions.js
+++ b/qml/Pages/functions.js
@@ -62,7 +62,12 @@ function loadSettings() {
     lib.fontSize = (Storage.getSetting("fontSize"))
     lib.radioStation = (Storage.getSetting("suStation")) // def. startup values
     lib.website = (Storage.getSetting("suWebsite"))
-    lib.musicSource = (Storage.getSetting("suUrl"))
+
+    var musicSource = (Storage.getSetting("suUrl"))
+    if(musicSource !== null && musicSource.length > 0) {
+        lib.musicSource = musicSource
+    }
+
     //lib.xmlLocation = (Storage.getSetting("xmlLocation"))
     console.log("Settings loaded")
 }

--- a/qml/Pages/functions.js
+++ b/qml/Pages/functions.js
@@ -64,7 +64,6 @@ function loadSettings() {
     lib.website = (Storage.getSetting("suWebsite"))
     lib.musicSource = (Storage.getSetting("suUrl"))
     //lib.xmlLocation = (Storage.getSetting("xmlLocation"))
-    refreshMpris()
     console.log("Settings loaded")
 }
 
@@ -101,7 +100,6 @@ function chooseStation(listM, i) {
         lib.radioStation = listM.get(0).title
         lib.stationIndex = 1 // for the cover action
     }
-    refreshMpris()
 }
 
 function saveFontSize (size) {
@@ -113,7 +111,6 @@ function refreshList(whichList) {
     whichList.clear()
     Storage.initialize()
     Storage.getFavsFromDB(whichList)
-    refreshMpris()
 }
 
 function overwriteFavs(sourceList) {

--- a/qml/harbour-nettiradio.qml
+++ b/qml/harbour-nettiradio.qml
@@ -33,7 +33,7 @@ import QtQuick 2.1
 import QtMultimedia 5.0
 import Sailfish.Silica 1.0
 import QtQuick.LocalStorage 2.0
-//import org.nemomobile.mpris 1.0
+import Amber.Mpris 1.0
 import "Pages"
 import "Pages/StationLists"
 import "Pages/storage.js" as Storage
@@ -66,34 +66,11 @@ ApplicationWindow
         }
         onMutedChanged: pauseStream()
     }
-
-    function refreshMpris() {
-        console.log("mpris not enabled on harbour builds")
-        /*
-        mprisPlayer.artist = lib.radioStation
-        mprisPlayer.song = "Nettiradio"
-        switch (lib.playing) {
-        case true:
-            mprisPlayer.playbackStatus = Mpris.Playing
-            break;
-        case false:
-            if (lib.stopped) {
-                mprisPlayer.playbackStatus = Mpris.Paused
-            }
-            else {
-                mprisPlayer.setCanPause(false)
-                mprisPlayer.playbackStatus = Mpris.Paused
-            }
-            break;
-        default:
-            mprisPlayer.playbackStatus = Mpris.Paused
-        }*/
-    }
-    /*
+    
     MprisPlayer {
         id: mprisPlayer
-        property string artist
-        property string song
+
+        metaData.title: lib.radioStation.length > 0 ? lib.radioStation : "Nettiradio"
 
         serviceName: "harbour-nettiradio"
         identity: "Nettiradio"
@@ -101,36 +78,25 @@ ApplicationWindow
         supportedUriSchemes: ["file"]
         supportedMimeTypes: ["audio/x-wav", "audio/x-vorbis+ogg", "audio/mpeg", "audio/mp4a-latm", "audio/x-aiff"]
 
-        playbackStatus: Mpris.Stopped
-        loopStatus: Mpris.None
+        playbackStatus: lib.playing ? Mpris.Playing : (lib.stopped ? Mpris.Stopped : Mpris.Paused)
+        onPlaybackStatusChanged: console.log("Playback status:", playbackStatus)
+        loopStatus: Mpris.LoopNone
         shuffle: false
         volume: lib.volume
 
         canControl: true
-        canPause: true
-        canPlay: true
+        canPause: playbackStatus !== Mpris.Stopped
+        canPlay: playbackStatus !== Mpris.Playing && lib.musicSource.length > 0
         canSeek: false
-        canGoNext: true
-        canGoPrevious: true
+        canGoNext: lib.stationCount > 0
+        canGoPrevious: canGoNext
         hasTrackList:false
 
         onPlayRequested: playStream()
-        onPlayPauseRequested: pauseStream()
+        onPlayPauseRequested: lib.playing ? pauseStream() : playStream()
         onStopRequested: stopStream()
         onNextRequested: TheFunctions.chooseStation(qmlListModel,(lib.stationIndex))
         onPreviousRequested: TheFunctions.chooseStation(qmlListModel,(lib.stationIndex - 2))
-
-        onArtistChanged: {
-            var metadata = mprisPlayer.metadata
-            metadata[Mpris.metadataToString(Mpris.Artist)] = artist
-            mprisPlayer.metadata = metadata
-        }
-
-        onSongChanged: {
-            var metadata = mprisPlayer.metadata
-            metadata[Mpris.metadataToString(Mpris.Title)] = song
-            mprisPlayer.metadata = metadata
-        }
 
         // I'll list these just incase I figure out what to do with them :)
         onSeekRequested: {}
@@ -139,7 +105,7 @@ ApplicationWindow
         onLoopStatusRequested: {}
         onShuffleRequested: {}
     }
-    */
+    
 
     // Dunno what I did but seems to work
     Timer {
@@ -251,7 +217,6 @@ ApplicationWindow
         console.log("this many stations: " + i)
         Storage.getFavsFromDB(qmlListModel)
         console.log("Got favs from db")
-        refreshMpris()
     }
     allowedOrientations: Orientation.All
     _defaultPageOrientations: Orientation.All
@@ -265,18 +230,15 @@ ApplicationWindow
     function pauseStream() {
         playMusic.pause()
         resurrector.stop()
-        refreshMpris()
     }
 
     function playStream() {
         playMusic.play()
-        refreshMpris()
     }
 
     function stopStream() {
         playMusic.stop()
         resurrector.stop()
-        refreshMpris()
     }
 
     initialPage: Qt.resolvedUrl("Pages/MainPage.qml")

--- a/qml/harbour-nettiradio.qml
+++ b/qml/harbour-nettiradio.qml
@@ -197,7 +197,9 @@ ApplicationWindow
 
     ListModel { id:filteredModel }
 
-    ListModel { id:favModel }
+    ListModel { id:favModel
+        Component.onCompleted: TheFunctions.refreshList(favModel)
+    }
 
     function fillList() {
         lib.stationCount = stationsModel.count

--- a/qml/harbour-nettiradio.qml
+++ b/qml/harbour-nettiradio.qml
@@ -93,6 +93,7 @@ ApplicationWindow
         hasTrackList:false
 
         onPlayRequested: playStream()
+        onPauseRequested: pauseStream()
         onPlayPauseRequested: lib.playing ? pauseStream() : playStream()
         onStopRequested: stopStream()
         onNextRequested: TheFunctions.chooseStation(qmlListModel,(lib.stationIndex))


### PR DESCRIPTION
As Jolla Store now supports Mpris (via Amber) since Sailfish OS 4.4.0 ([source](https://forum.sailfishos.org/t/state-of-mpris-in-sfos/10642/6?u=direc85)), I decided to have a look at it again. I also found some (surprisingly ready!) old UI code that I polished up and decided to push in the same go! I tested this with Sony Xperia 10 III and AFAICT it all works flawlessly.

We still have to set `canPlay = true` and `canPause = true` in order to make the lock screen resume-from-pause work (which is super dumb -- Deezer for example doesn't let you resume the song!), but otherwise there are no hacks. Just a lot of simplifying the flow, and getting rid of unnecessary code (namely `refreshMpris()`) Sadly that broke Mpris support on older SFOS versions (at least `metaData` isn't available), but the "old Harbour version" (commenting the import and `MprisPlayer` out) works beautifully on my Jolla Phone on Sailfish OS 3.4.0! Even the animations!

- Restore Mpris support in a Harbour-compatible manner (Finally!)
- Use dynamic station button size and text elide in PlayerPanel.qml - fixes #8 
- Handle adding/removing favorites via long-press context menu (A lot more Sailfish-y way to do this)
- Animate add/removing stations (but not when searching)
- Add playing icon to currently playing item, with animations (prettier is better-er)